### PR TITLE
Ignoring misconfigured src attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,11 @@ var imageRetina = function(options){
 
 			var tmpSrc = [];
 			var match = src.match(reImageSrc);
+			
+			// not a valid src attribute
+			if (match === null){
+				return true;
+			}
 
 			for( var key in options.suffix ){
 				tmpSrc.push( match[1]+options.suffix[key]+match[2]+' '+key+'x' );


### PR DESCRIPTION
Do not exit gulp, if a wrong src attribute found (and then 'match' became 'null'), instead skip that <img> element, and continue with the next one.